### PR TITLE
Release 1.3.1 Build 4006

### DIFF
--- a/MasterEvent/Communication/MessageType.cs
+++ b/MasterEvent/Communication/MessageType.cs
@@ -22,4 +22,5 @@ public static class MessageType
     public const string PlayerStatUpdate = "playerStatUpdate";
     public const string WeatherUpdate = "weatherUpdate";
     public const string TimeUpdate = "timeUpdate";
+    public const string AllianceKick = "allianceKick";
 }

--- a/MasterEvent/Communication/ProtocolHandler.cs
+++ b/MasterEvent/Communication/ProtocolHandler.cs
@@ -68,6 +68,9 @@ public class ProtocolHandler(SessionManager session, DiceRollOverlay diceRollOve
             case MessageType.TimeUpdate:
                 HandleTimeUpdate(msg);
                 break;
+            case MessageType.AllianceKick:
+                HandleAllianceKick(msg);
+                break;
         }
     }
 
@@ -121,7 +124,7 @@ public class ProtocolHandler(SessionManager session, DiceRollOverlay diceRollOve
 
         // En mode alliance, ajouter le joueur s'il n'est pas dans le groupe local
         if (session.IsAllianceMode && msg.PlayerHash != null && msg.PlayerName != null)
-            session.AddAlliancePlayer(msg.PlayerHash, msg.PlayerName);
+            session.AddAlliancePlayer(msg.PlayerHash, msg.PlayerName, msg.GroupId);
 
         if (msg.PlayerHash != null)
             session.UpdatePlayerConnection(msg.PlayerHash, true);
@@ -424,5 +427,14 @@ public class ProtocolHandler(SessionManager session, DiceRollOverlay diceRollOve
         session.ApplyTime(msg.EorzeaTime);
         var hour = WeatherService.SecondsToHour(msg.EorzeaTime);
         Plugin.ChatGui.Print(string.Format(Loc.Get("Chat.TimeApplied"), $"{hour:00}:00"));
+    }
+
+    private void HandleAllianceKick(RelayMessage msg)
+    {
+        // Le joueur kické vérifie si c'est lui qui est ciblé
+        if (msg.TargetHash == null || msg.TargetHash != session.LocalPlayerHash) return;
+
+        Plugin.ChatGui.Print(Loc.Get("Chat.AllianceKicked"));
+        session.OnAllianceKicked?.Invoke();
     }
 }

--- a/MasterEvent/Communication/RelayMessage.cs
+++ b/MasterEvent/Communication/RelayMessage.cs
@@ -142,6 +142,10 @@ public class RelayMessage
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public uint EorzeaTime { get; set; }
 
+    [JsonPropertyName("groupId")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? GroupId { get; set; }
+
     public string Serialize() => JsonSerializer.Serialize(this);
 
     public static RelayMessage? Deserialize(string json)

--- a/MasterEvent/Configuration.cs
+++ b/MasterEvent/Configuration.cs
@@ -27,6 +27,8 @@ public class Configuration : IPluginConfiguration
     public bool SuppressInInstance { get; set; } = true;
     public bool DebugMode { get; set; }
     public bool SetupCompleted { get; set; }
+    public string? AllianceRoomCode { get; set; }
+    public bool AllianceIsCreator { get; set; }
     public bool RgpdConsentGiven { get; set; }
     public DateTime? RgpdConsentDate { get; set; }
     public int AcceptedRgpdVersion { get; set; }

--- a/MasterEvent/Localization/Strings.en.resx
+++ b/MasterEvent/Localization/Strings.en.resx
@@ -348,8 +348,11 @@
   <data name="Advanced.PluginPartial" xml:space="preserve">
     <value>Partially active</value>
   </data>
-  <data name="Advanced.PluginWeathermanHint" xml:space="preserve">
-    <value>Required for weather and time control</value>
+  <data name="Advanced.WeatherEngine" xml:space="preserve">
+    <value>Weather/Time engine</value>
+  </data>
+  <data name="Advanced.PluginActive" xml:space="preserve">
+    <value>Active</value>
   </data>
   <data name="Advanced.DebugMode" xml:space="preserve">
     <value>Debug mode</value>
@@ -635,6 +638,12 @@
   <data name="Alliance.Join" xml:space="preserve">
     <value>Join</value>
   </data>
+  <data name="Alliance.Kick" xml:space="preserve">
+    <value>Remove from alliance</value>
+  </data>
+  <data name="Chat.AllianceKicked" xml:space="preserve">
+    <value>[MasterEvent] You have been removed from the alliance by the GM.</value>
+  </data>
 
   <!-- Relay connection feedback -->
   <data name="Chat.RgpdRequired" xml:space="preserve">
@@ -907,8 +916,7 @@ Disable to stay connected in instances.</value>
     <value>Apply</value>
   </data>
   <data name="Weather.ApplyTooltip" xml:space="preserve">
-    <value>Sends the selected weather to all connected players.
-Requires the Weatherman plugin on each player.</value>
+    <value>Sends the selected weather to all connected players.</value>
   </data>
   <data name="Chat.WeatherSet" xml:space="preserve">
     <value>[MasterEvent] Weather set: {0}</value>
@@ -917,7 +925,7 @@ Requires the Weatherman plugin on each player.</value>
     <value>[MasterEvent] Weather applied: {0}</value>
   </data>
   <data name="Chat.WeatherNotApplied" xml:space="preserve">
-    <value>[MasterEvent] Weather received: {0} (Weatherman not installed)</value>
+    <value>[MasterEvent] Weather received: {0} (weather engine unavailable)</value>
   </data>
   <data name="Weather.Time" xml:space="preserve">
     <value>Eorzean Time</value>
@@ -926,8 +934,7 @@ Requires the Weatherman plugin on each player.</value>
     <value>Apply time</value>
   </data>
   <data name="Weather.TimeTooltip" xml:space="preserve">
-    <value>Sets the Eorzean time for all connected players.
-Requires the Weatherman plugin for time control.</value>
+    <value>Sets the Eorzean time for all connected players.</value>
   </data>
   <data name="Chat.TimeSet" xml:space="preserve">
     <value>[MasterEvent] Time set: {0}</value>

--- a/MasterEvent/Localization/Strings.resx
+++ b/MasterEvent/Localization/Strings.resx
@@ -376,8 +376,11 @@
   <data name="Advanced.PluginPartial" xml:space="preserve">
     <value>Partiellement actif</value>
   </data>
-  <data name="Advanced.PluginWeathermanHint" xml:space="preserve">
-    <value>Requis pour la m&#233;t&#233;o et l'heure</value>
+  <data name="Advanced.WeatherEngine" xml:space="preserve">
+    <value>Moteur m&#233;t&#233;o/heure</value>
+  </data>
+  <data name="Advanced.PluginActive" xml:space="preserve">
+    <value>Actif</value>
   </data>
   <data name="Advanced.DebugMode" xml:space="preserve">
     <value>Mode debug</value>
@@ -670,6 +673,12 @@
   <data name="Alliance.Join" xml:space="preserve">
     <value>Rejoindre</value>
   </data>
+  <data name="Alliance.Kick" xml:space="preserve">
+    <value>Retirer de l'alliance</value>
+  </data>
+  <data name="Chat.AllianceKicked" xml:space="preserve">
+    <value>[MasterEvent] Vous avez &#233;t&#233; retir&#233; de l'alliance par le MJ.</value>
+  </data>
 
   <!-- Relay connection feedback -->
   <data name="Chat.RgpdRequired" xml:space="preserve">
@@ -948,8 +957,7 @@ D&#233;sactiver pour rester connect&#233; en instance.</value>
     <value>Appliquer</value>
   </data>
   <data name="Weather.ApplyTooltip" xml:space="preserve">
-    <value>Envoie la m&#233;t&#233;o s&#233;lectionn&#233;e &#224; tous les joueurs connect&#233;s.
-N&#233;cessite le plugin Weatherman chez chaque joueur.</value>
+    <value>Envoie la m&#233;t&#233;o s&#233;lectionn&#233;e &#224; tous les joueurs connect&#233;s.</value>
   </data>
   <data name="Chat.WeatherSet" xml:space="preserve">
     <value>[MasterEvent] M&#233;t&#233;o d&#233;finie : {0}</value>
@@ -958,7 +966,7 @@ N&#233;cessite le plugin Weatherman chez chaque joueur.</value>
     <value>[MasterEvent] M&#233;t&#233;o appliqu&#233;e : {0}</value>
   </data>
   <data name="Chat.WeatherNotApplied" xml:space="preserve">
-    <value>[MasterEvent] M&#233;t&#233;o re&#231;ue : {0} (Weatherman non install&#233;)</value>
+    <value>[MasterEvent] M&#233;t&#233;o re&#231;ue : {0} (moteur m&#233;t&#233;o non disponible)</value>
   </data>
   <data name="Weather.Time" xml:space="preserve">
     <value>Heure &#233;orz&#233;enne</value>
@@ -967,8 +975,7 @@ N&#233;cessite le plugin Weatherman chez chaque joueur.</value>
     <value>Appliquer l'heure</value>
   </data>
   <data name="Weather.TimeTooltip" xml:space="preserve">
-    <value>D&#233;finit l'heure &#233;orz&#233;enne pour tous les joueurs connect&#233;s.
-N&#233;cessite le plugin Weatherman pour le contr&#244;le du temps.</value>
+    <value>D&#233;finit l'heure &#233;orz&#233;enne pour tous les joueurs connect&#233;s.</value>
   </data>
   <data name="Chat.TimeSet" xml:space="preserve">
     <value>[MasterEvent] Heure d&#233;finie : {0}</value>

--- a/MasterEvent/MasterEvent.csproj
+++ b/MasterEvent/MasterEvent.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Dalamud.NET.Sdk/14.0.2">
   <PropertyGroup>
-    <Version>1.3.1.4005</Version>
+    <Version>1.3.1.4006</Version>
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
     <IsPackable>false</IsPackable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/MasterEvent/Models/PlayerData.cs
+++ b/MasterEvent/Models/PlayerData.cs
@@ -25,4 +25,6 @@ public class PlayerData
     public bool CanEdit { get; set; }
     [JsonIgnore] public bool IsConnected { get; set; }
     [JsonIgnore] public bool IsAlliancePlayer { get; set; }
+    [JsonIgnore] public string? GroupId { get; set; }
+    [JsonIgnore] public string? GroupLabel { get; set; }
 }

--- a/MasterEvent/Plugin.cs
+++ b/MasterEvent/Plugin.cs
@@ -69,7 +69,8 @@ public sealed class Plugin : IDalamudPlugin
         IToastGui toastGui,
         IObjectTable objectTable,
         IDataManager dataManager,
-        ISigScanner sigScanner)
+        ISigScanner sigScanner,
+        IGameInteropProvider gameInterop)
     {
         Plugin.pluginInterface = pluginInterface;
         Plugin.chatGuiStatic = chatGui;
@@ -119,7 +120,7 @@ public sealed class Plugin : IDalamudPlugin
         relayClient = new RelayClient();
         protocolHandler = new ProtocolHandler(sessionManager, diceRollOverlay, Configuration);
         sessionManager.SetRelayClient(relayClient);
-        sessionManager.SetWeatherService(new WeatherService(pluginInterface, sigScanner));
+        sessionManager.SetWeatherService(new WeatherService(sigScanner, gameInterop));
 
         relayClient.OnMessageReceived += protocolHandler.HandleMessage;
         relayClient.OnConnected += OnRelayConnected;
@@ -156,11 +157,19 @@ public sealed class Plugin : IDalamudPlugin
         partyWatcher.OnLeaderChanged += OnLeaderChanged;
         partyWatcher.OnMembersChanged += OnMembersChanged;
         sessionManager.OnPromotionChanged += OnPromotionChanged;
+        sessionManager.OnAllianceKicked = () => LeaveAllianceRoom();
         condition.ConditionChange += OnConditionChange;
 
         instanceSuppressed = condition[ConditionFlag.BoundByDuty]
                              || condition[ConditionFlag.BoundByDuty56]
                              || condition[ConditionFlag.BoundByDuty95];
+
+        // Restaurer le mode alliance si un code était persisté (auto-rejoin après reload/crash)
+        if (!string.IsNullOrEmpty(Configuration.AllianceRoomCode))
+        {
+            sessionManager.AllianceRoomCode = Configuration.AllianceRoomCode;
+            Plugin.Log.Info($"[MasterEvent] Alliance restaurée : {Configuration.AllianceRoomCode}");
+        }
 
         framework.Update += OnFrameworkUpdate;
 
@@ -269,7 +278,7 @@ public sealed class Plugin : IDalamudPlugin
             sessionManager.CheckAutoBroadcast();
         }
 
-        // Réappliquer l'override de temps chaque frame (contrer l'écrasement par Weatherman)
+        // Maintenir l'heure éorzéenne à la valeur d'override chaque frame
         sessionManager.TickTimeOverride();
     }
 
@@ -348,15 +357,22 @@ public sealed class Plugin : IDalamudPlugin
     private void OnPartyJoined()
     {
         UpdateRole();
+
+        // En mode alliance, renseigner le groupe local pour le badge
+        if (sessionManager.IsAllianceMode && sessionManager.LocalGroupId == null)
+        {
+            sessionManager.LocalGroupId = partyWatcher.PartyId.ToString();
+            sessionManager.AssignLocalGroup();
+        }
+
         sessionManager.SyncPartyMembers(PartyList, playerState);
         chatGui.Print(string.Format(Loc.Get("Chat.PartyJoined"), sessionManager.IsGm ? Loc.Get("Role.Gm") : Loc.Get("Role.Player")));
 
         if (!sessionManager.IsGm && Configuration.AutoOpenPlayerWindow)
             playerWindow.IsOpen = true;
 
-        // En mode alliance, on est déjà dans la bonne room
-        if (!sessionManager.IsAllianceMode)
-            ConnectToRelay();
+        // Connecter au relay (en mode alliance, reconnecter à la room persistée)
+        ConnectToRelay();
     }
 
     private void OnPartyLeft()
@@ -501,6 +517,9 @@ public sealed class Plugin : IDalamudPlugin
         var playerName = ObjectTable.LocalPlayer?.Name.ToString() ?? "Unknown";
         var playerHash = GeneratePlayerHash(playerState.ContentId);
 
+        // En mode alliance, transmettre le vrai party ID comme groupId pour identifier le groupe d'origine
+        var groupId = sessionManager.IsAllianceMode ? partyWatcher.PartyId.ToString() : null;
+
         var joinMsg = new RelayMessage
         {
             Type = MessageType.Join,
@@ -509,6 +528,7 @@ public sealed class Plugin : IDalamudPlugin
             PlayerHash = playerHash,
             IsLeader = sessionManager.IsGm,
             Version = Constants.PluginVersion,
+            GroupId = groupId,
         };
         _ = relayClient.SendAsync(joinMsg);
 
@@ -632,6 +652,12 @@ public sealed class Plugin : IDalamudPlugin
     private void EnableAllianceMode()
     {
         sessionManager.AllianceRoomCode = SessionManager.GenerateAllianceCode();
+        sessionManager.LocalGroupId = partyWatcher.PartyId.ToString();
+        Configuration.AllianceRoomCode = sessionManager.AllianceRoomCode;
+        Configuration.AllianceIsCreator = true;
+        Configuration.Save();
+        // Assigner le groupe local aux membres existants
+        sessionManager.AssignLocalGroup();
         _ = relayClient.DisconnectAsync();
         sessionManager.IsConnected = false;
         sessionManager.ConnectedPlayerCount = 0;
@@ -643,7 +669,11 @@ public sealed class Plugin : IDalamudPlugin
     private void DisableAllianceMode()
     {
         sessionManager.AllianceRoomCode = null;
+        sessionManager.LocalGroupId = null;
         sessionManager.ClearAlliancePlayers();
+        Configuration.AllianceRoomCode = null;
+        Configuration.AllianceIsCreator = false;
+        Configuration.Save();
         _ = relayClient.DisconnectAsync();
         sessionManager.IsConnected = false;
         sessionManager.ConnectedPlayerCount = 0;
@@ -655,6 +685,12 @@ public sealed class Plugin : IDalamudPlugin
     private void JoinAllianceRoom(string code)
     {
         sessionManager.AllianceRoomCode = code.ToUpperInvariant();
+        sessionManager.LocalGroupId = partyWatcher.PartyId.ToString();
+        Configuration.AllianceRoomCode = sessionManager.AllianceRoomCode;
+        Configuration.AllianceIsCreator = false;
+        Configuration.Save();
+        // Assigner le groupe local aux membres existants
+        sessionManager.AssignLocalGroup();
         _ = relayClient.DisconnectAsync();
         sessionManager.IsConnected = false;
         sessionManager.ConnectedPlayerCount = 0;

--- a/MasterEvent/Services/SessionManager.cs
+++ b/MasterEvent/Services/SessionManager.cs
@@ -52,6 +52,7 @@ public class SessionManager(string pluginConfigDir)
     // Mode Alliance
     public string? AllianceRoomCode { get; set; }
     public bool IsAllianceMode => !string.IsNullOrEmpty(AllianceRoomCode);
+    public string? LocalGroupId { get; set; }
 
     private static readonly char[] AllianceCharset = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789".ToCharArray();
 
@@ -65,6 +66,7 @@ public class SessionManager(string pluginConfigDir)
     }
 
     public event Action<bool>? OnPromotionChanged;
+    public Action? OnAllianceKicked { get; set; }
 
     public List<PlayerData> PartyMembers { get; } = new();
 
@@ -115,34 +117,23 @@ public class SessionManager(string pluginConfigDir)
         weatherService?.TickTimeOverride();
     }
 
-    public bool IsWeathermanInstalled => weatherService?.IsWeathermanInstalled ?? false;
-    public bool IsTimePatchActive => weatherService?.IsTimePatchActive ?? false;
-    public bool IsWeatherPatchActive => weatherService?.IsWeatherPatchActive ?? false;
+    public bool IsWeatherEngineReady => weatherService?.IsReady ?? false;
+    public bool IsWeatherOverrideActive => weatherService?.IsWeatherOverrideActive ?? false;
+    public bool IsTimeOverrideActive => weatherService?.IsTimeOverrideActive ?? false;
 
     public void DisposeWeatherService()
     {
         weatherService?.Dispose();
     }
 
-    /// <summary>
-    /// Récupère les météos disponibles pour la zone courante.
-    /// </summary>
     public Dictionary<byte, string> GetAvailableWeathers()
     {
         return weatherService?.GetWeathersForCurrentZone() ?? WeatherService.FallbackWeathers;
     }
-
-    /// <summary>
-    /// Récupère l'ID d'icône de jeu pour une météo.
-    /// </summary>
     public uint GetWeatherIconId(byte weatherId)
     {
         return weatherService?.GetWeatherIconId(weatherId) ?? 0;
     }
-
-    /// <summary>
-    /// Envoie la météo sélectionnée à tous les joueurs connectés.
-    /// </summary>
     public void BroadcastWeather(byte weatherId, string weatherName)
     {
         if (relayClient is not { IsConnected: true } || !CanEdit) return;
@@ -819,11 +810,19 @@ public class SessionManager(string pluginConfigDir)
             {
                 existing.Name = member.Name.ToString();
                 existing.IsGm = i == leaderIndex;
+                // En mode alliance, assigner le groupe local
+                if (IsAllianceMode && existing.GroupId == null && !string.IsNullOrEmpty(LocalGroupId))
+                {
+                    existing.GroupId = LocalGroupId;
+                    existing.GroupLabel = GetOrAssignGroupLabel(LocalGroupId);
+                }
             }
             else
             {
                 var defaultHpMax = ActiveTemplate?.DefaultPlayerHpMax ?? 100;
                 var defaultMpMax = ActiveTemplate?.DefaultPlayerMpMax ?? 100;
+                var groupId = IsAllianceMode ? LocalGroupId : null;
+                var groupLabel = IsAllianceMode && !string.IsNullOrEmpty(LocalGroupId) ? GetOrAssignGroupLabel(LocalGroupId) : null;
                 PartyMembers.Add(new PlayerData
                 {
                     Hash = hash,
@@ -836,6 +835,8 @@ public class SessionManager(string pluginConfigDir)
                     Counters = ActiveTemplate?.CounterDefinitions?.Select(cd => cd.ToCounter()).ToList(),
                     Stats = ActiveTemplate?.StatDefinitions?.Select(sd => sd.ToStatValue()).ToList(),
                     IsGm = i == leaderIndex,
+                    GroupId = groupId,
+                    GroupLabel = groupLabel,
                 });
                 addedOrRemoved = true;
             }
@@ -862,11 +863,37 @@ public class SessionManager(string pluginConfigDir)
             player.IsConnected = false;
     }
 
+    // Groupes connus dans l'alliance (groupId → label attribué)
+    private readonly Dictionary<string, string> allianceGroupLabels = new();
+    private static readonly string[] GroupLetters = ["A", "B", "C", "D", "E", "F", "G", "H"];
+    private string GetOrAssignGroupLabel(string? groupId)
+    {
+        if (string.IsNullOrEmpty(groupId)) return "?";
+        if (allianceGroupLabels.TryGetValue(groupId, out var label)) return label;
+
+        var nextIndex = allianceGroupLabels.Count;
+        label = nextIndex < GroupLetters.Length ? GroupLetters[nextIndex] : $"G{nextIndex + 1}";
+        allianceGroupLabels[groupId] = label;
+        return label;
+    }
+
+    public Dictionary<string, int> GetGroupCounts()
+    {
+        var counts = new Dictionary<string, int>();
+        foreach (var p in PartyMembers.Where(p => !p.IsGm))
+        {
+            var label = p.GroupLabel ?? "?";
+            counts[label] = counts.GetValueOrDefault(label, 0) + 1;
+        }
+        return counts;
+    }
+
     // Ajoute un joueur alliance (d'un autre groupe FFXIV) à la liste des membres.
-    public void AddAlliancePlayer(string hash, string name)
+    public void AddAlliancePlayer(string hash, string name, string? groupId = null)
     {
         if (PartyMembers.Any(p => p.Hash == hash)) return;
 
+        var groupLabel = GetOrAssignGroupLabel(groupId);
         var defaultHpMax = ActiveTemplate?.DefaultPlayerHpMax ?? 100;
         var defaultMpMax = ActiveTemplate?.DefaultPlayerMpMax ?? 100;
         PartyMembers.Add(new PlayerData
@@ -881,24 +908,53 @@ public class SessionManager(string pluginConfigDir)
             Stats = ActiveTemplate?.StatDefinitions?.Select(sd => sd.ToStatValue()).ToList(),
             IsConnected = true,
             IsAlliancePlayer = true,
+            GroupId = groupId,
+            GroupLabel = groupLabel,
         });
 
         if (IsGm && relayClient is { IsConnected: true })
             BroadcastPlayerUpdate();
     }
 
-    // Retire un joueur alliance de la liste des membres.
+    // Retire un joueur alliance de la liste des membres et notifie le joueur kické.
     public void RemoveAlliancePlayer(string hash)
     {
         var removed = PartyMembers.RemoveAll(p => p.Hash == hash && p.IsAlliancePlayer);
         if (removed > 0 && IsGm && relayClient is { IsConnected: true })
+        {
+            // Notifier le joueur kické
+            var kickMsg = new RelayMessage
+            {
+                Type = MessageType.AllianceKick,
+                TargetHash = hash,
+            };
+            _ = relayClient.SendAsync(kickMsg);
+
             BroadcastPlayerUpdate();
+        }
+    }
+    public void AssignLocalGroup()
+    {
+        if (string.IsNullOrEmpty(LocalGroupId)) return;
+        var label = GetOrAssignGroupLabel(LocalGroupId);
+        foreach (var p in PartyMembers.Where(p => !p.IsAlliancePlayer))
+        {
+            p.GroupId = LocalGroupId;
+            p.GroupLabel = label;
+        }
     }
 
     // Retire tous les joueurs alliance de la liste (appelé lors de la désactivation du mode alliance).
     public void ClearAlliancePlayers()
     {
         PartyMembers.RemoveAll(p => p.IsAlliancePlayer);
+        allianceGroupLabels.Clear();
+        // Nettoyer les labels des joueurs locaux
+        foreach (var p in PartyMembers)
+        {
+            p.GroupId = null;
+            p.GroupLabel = null;
+        }
     }
 
     public void BroadcastPlayerUpdate()

--- a/MasterEvent/Services/WeatherService.cs
+++ b/MasterEvent/Services/WeatherService.cs
@@ -314,6 +314,7 @@ public class WeatherService : IDisposable
 
     // Nettoyage
 
+    // ReSharper disable once RedundantUnsafeContext
     public unsafe void Dispose()
     {
         // Restaurer la météo du jeu si override actif

--- a/MasterEvent/Services/WeathermanIpc.cs
+++ b/MasterEvent/Services/WeathermanIpc.cs
@@ -14,7 +14,6 @@ public class WeatherService : IDisposable
     // Hook météo
     private readonly Hook<UpdateTerritoryWeatherDelegate>? weatherHook;
     private bool weatherOverrideEnabled;
-    private byte overrideWeatherId;
 
     // Patch temps (rendu)
     private readonly nint timePatchAddr;
@@ -86,10 +85,10 @@ public class WeatherService : IDisposable
 
 
 
-    private void WeatherDetour(nint weatherManager)
-    {
-        // Ne rien faire : bloque la mise à jour automatique de la météo
-    }
+    // Detour no-op : doit rester une méthode d'instance (delegate pour le hook)
+#pragma warning disable CA1822
+    private void WeatherDetour(nint weatherManager) { }
+#pragma warning restore CA1822
 
 
     public unsafe void SetWeather(byte weatherId)
@@ -105,7 +104,6 @@ public class WeatherService : IDisposable
 
                 weatherHook.Disable();
                 weatherOverrideEnabled = false;
-                overrideWeatherId = 0;
                 Plugin.Log.Info("[WeatherService] Override météo désactivé, météo du jeu restaurée");
             }
             return;
@@ -121,7 +119,6 @@ public class WeatherService : IDisposable
         // Écriture directe dans la mémoire du jeu
         env->ActiveWeather = weatherId;
         env->TransitionTime = 0.5f;
-        overrideWeatherId = weatherId;
 
         // Activer le hook pour empêcher le jeu de changer la météo
         if (!weatherOverrideEnabled && weatherHook != null)
@@ -207,13 +204,13 @@ public class WeatherService : IDisposable
         try
         {
             var territorySheet = Plugin.DataManager.GetExcelSheet<TerritoryType>();
-            if (territorySheet != null && territorySheet.TryGetRow(territoryId, out var territory))
+            if (territorySheet.TryGetRow(territoryId, out var territory))
             {
                 var weatherRateRef = territory.WeatherRate;
                 if (weatherRateRef.RowId != 0)
                 {
                     var weatherRateSheet = Plugin.DataManager.GetExcelSheet<WeatherRate>();
-                    if (weatherRateSheet != null && weatherRateSheet.TryGetRow(weatherRateRef.RowId, out var weatherRate))
+                    if (weatherRateSheet.TryGetRow(weatherRateRef.RowId, out var weatherRate))
                     {
                         for (var i = 0; i < weatherRate.Weather.Count; i++)
                         {
@@ -295,8 +292,6 @@ public class WeatherService : IDisposable
         try
         {
             var sheet = Plugin.DataManager.GetExcelSheet<Weather>();
-            if (sheet == null) return;
-
             foreach (var row in sheet)
             {
                 var id = (byte)row.RowId;
@@ -319,17 +314,14 @@ public class WeatherService : IDisposable
 
     // Nettoyage
 
-    public void Dispose()
+    public unsafe void Dispose()
     {
         // Restaurer la météo du jeu si override actif
         if (weatherOverrideEnabled && weatherHook != null)
         {
-            unsafe
-            {
-                var wm = FFXIVClientStructs.FFXIV.Client.Game.WeatherManager.Instance();
-                if (wm != null)
-                    weatherHook.Original((nint)wm);
-            }
+            var wm = FFXIVClientStructs.FFXIV.Client.Game.WeatherManager.Instance();
+            if (wm != null)
+                weatherHook.Original((nint)wm);
             weatherHook.Disable();
         }
 

--- a/MasterEvent/Services/WeathermanIpc.cs
+++ b/MasterEvent/Services/WeathermanIpc.cs
@@ -1,190 +1,162 @@
 using System;
 using System.Collections.Generic;
 using Dalamud;
-using Dalamud.Plugin;
-using Dalamud.Plugin.Ipc;
+using Dalamud.Hooking;
 using Dalamud.Plugin.Services;
+using FFXIVClientStructs.FFXIV.Client.Graphics.Environment;
 using Lumina.Excel.Sheets;
 
 namespace MasterEvent.Services;
 
 
-// Utilise Weatherman IPC pour les données (listes météo par zone, noms) et applique les changements via patch mémoire direct (même méthode que Weatherman).
 public class WeatherService : IDisposable
 {
+    // Hook météo
+    private readonly Hook<UpdateTerritoryWeatherDelegate>? weatherHook;
+    private bool weatherOverrideEnabled;
+    private byte overrideWeatherId;
 
-    private readonly ICallGateSubscriber<Dictionary<byte, string>> ipcGetWeathers;
-    private readonly ICallGateSubscriber<Dictionary<ushort, (List<byte> WeatherList, string EnvbFile)>> ipcGetWeatherList;
-    private readonly ICallGateSubscriber<bool> ipcIsPluginEnabled;
-    private readonly nint weatherPatchAddr;
-    private readonly byte[]? weatherOrigBytes;
-    private bool weatherPatchEnabled;
+    // Patch temps (rendu)
     private readonly nint timePatchAddr;
     private nint timeValueAddr;
     private readonly byte[]? timeOrigBytes;
     private bool timePatchEnabled;
-    public bool IsTimePatchActive => timePatchEnabled;
-    public bool IsWeatherPatchActive => weatherPatchEnabled;
+    private uint overrideTimeSeconds;
 
-    // Vérifie si Weatherman est installé et actif via IPC.
-    public bool IsWeathermanInstalled
-    {
-        get
-        {
-            try { return ipcIsPluginEnabled.InvokeFunc(); }
-            catch { return false; }
-        }
-    }
-    private uint activeTimeOverride; // 0 = pas d'override
-
+    // Données météo (Lumina)
     private readonly Dictionary<byte, uint> weatherIcons = new();
-    public static readonly Dictionary<byte, string> FallbackWeathers = new()
-    {
-        { 1, "Ciel dégagé" },
-        { 2, "Beau temps" },
-        { 3, "Couvert" },
-        { 4, "Pluie" },
-        { 7, "Brouillard" },
-        { 8, "Orage" },
-        { 9, "Tempête de sable" },
-        { 14, "Neige" },
-        { 15, "Blizzard" },
-        { 16, "Canicule" },
-    };
+    private readonly Dictionary<byte, string> weatherNames = new();
+    private readonly Dictionary<ushort, Dictionary<byte, string>> territoryWeatherCache = new();
+
+    // Signatures
+    // Hook météo : fonction de mise à jour météo du jeu (approche inspirée de Brio)
+    private const string UpdateWeatherSig = "48 89 5C 24 ?? 55 56 57 48 83 EC ?? 48 8B F9 48 8D 0D";
+    // Patch temps : fonction de rendu du temps (approche Weatherman — seule méthode affectant le visuel)
+    private const string TimeRenderSig = "48 89 5C 24 ?? 57 48 83 EC 30 4C 8B 15";
+    private const int TimePatchOffset = 0x19;
+    private const int TimePatchSize = 7;          // 3 bytes opcode + 4 bytes imm32
+    private const int TimeValueOffsetInPatch = 3;  // Position de la valeur imm32 dans le patch
+
+    // Delegate pour le hook météo
+    private delegate void UpdateTerritoryWeatherDelegate(nint weatherManager);
+
+    // Propriétés publiques
+    public bool IsWeatherOverrideActive => weatherOverrideEnabled;
+    public bool IsTimeOverrideActive => timePatchEnabled;
+    public bool IsReady { get; }
 
     public const uint SecondsInDay = 60 * 60 * 24;
 
-    // Signature de la fonction de rendu météo (identique à Weatherman pour compatibilité 100%)
-    private const string WeatherRenderSig = "48 89 5C 24 ?? 57 48 83 EC 30 80 B9 ?? ?? ?? ?? ?? 49 8B F8 0F 29 74 24 ?? 48 8B D9 0F 28 F1";
-    private const int WeatherPatchOffset = 0x55;
-    private const string TimeRenderSig = "48 89 5C 24 ?? 57 48 83 EC 30 4C 8B 15";
-    private const int TimePatchOffset = 0x19;
-    private const int TimePatchSize = 7; // 7 bytes : opcode (3) + imm32 (4)
-    private const int TimeValueOffsetInPatch = 3; // Les 4 bytes imm32 commencent à l'offset 3 du patch
-    public WeatherService(IDalamudPluginInterface pluginInterface, ISigScanner sigScanner)
+    public WeatherService(ISigScanner sigScanner, IGameInteropProvider gameInterop)
     {
-        ipcGetWeathers = pluginInterface.GetIpcSubscriber<Dictionary<byte, string>>("Weatherman.DataGetWeathers");
-        ipcGetWeatherList = pluginInterface.GetIpcSubscriber<Dictionary<ushort, (List<byte>, string)>>("Weatherman.DataGetWeatherList");
-        ipcIsPluginEnabled = pluginInterface.GetIpcSubscriber<bool>("Weatherman.IsPluginEnabled");
+        var weatherOk = false;
+        var timeOk = false;
+
+        // Hook de la fonction de mise à jour météo (approche Brio : no-op detour)
         try
         {
-            var funcAddr = sigScanner.ScanText(WeatherRenderSig);
-            weatherPatchAddr = funcAddr + WeatherPatchOffset;
-            SafeMemory.ReadBytes(weatherPatchAddr, 4, out weatherOrigBytes);
-            Plugin.Log.Info($"[MasterEvent] Weather render patch address found: {weatherPatchAddr:X}");
+            var weatherAddr = sigScanner.ScanText(UpdateWeatherSig);
+            weatherHook = gameInterop.HookFromAddress<UpdateTerritoryWeatherDelegate>(weatherAddr, WeatherDetour);
+            weatherOk = true;
+            Plugin.Log.Info($"[WeatherService] Hook météo initialisé : {weatherAddr:X}");
         }
         catch (Exception ex)
         {
-            Plugin.Log.Error($"[MasterEvent] Weather render signature scan failed: {ex.Message}");
-            weatherPatchAddr = nint.Zero;
+            Plugin.Log.Error($"[WeatherService] Échec du hook météo : {ex.Message}");
         }
 
-        // Localiser l'adresse du patch temps et sauvegarder les bytes originaux
+        // Localiser l'adresse du patch temps (rendu) et sauvegarder les bytes originaux
         try
         {
             var timeFuncAddr = sigScanner.ScanText(TimeRenderSig);
             timePatchAddr = timeFuncAddr + TimePatchOffset;
             SafeMemory.ReadBytes(timePatchAddr, TimePatchSize, out timeOrigBytes);
-            Plugin.Log.Info($"[MasterEvent] Time render patch address found: {timePatchAddr:X}");
+            timeOk = true;
+            Plugin.Log.Info($"[WeatherService] Patch temps localisé : {timePatchAddr:X}");
         }
         catch (Exception ex)
         {
-            Plugin.Log.Warning($"[MasterEvent] Time signature scan failed: {ex.Message}");
+            Plugin.Log.Error($"[WeatherService] Échec scan signature temps : {ex.Message}");
             timePatchAddr = nint.Zero;
         }
 
-        LoadWeatherIcons();
+        IsReady = weatherOk && timeOk;
+        LoadWeatherData();
     }
 
 
-    public Dictionary<byte, string> GetAllWeathers()
-    {
-        try
-        {
-            var list = ipcGetWeathers.InvokeFunc();
-            if (list is { Count: > 0 }) return list;
-        }
-        catch { /* Weatherman indisponible */ }
 
-        return FallbackWeathers;
+    private void WeatherDetour(nint weatherManager)
+    {
+        // Ne rien faire : bloque la mise à jour automatique de la météo
     }
 
-    public Dictionary<byte, string> GetWeathersForCurrentZone()
+
+    public unsafe void SetWeather(byte weatherId)
     {
-        var territoryId = Plugin.ClientState.TerritoryType;
-        if (territoryId == 0) return GetAllWeathers();
-
-        try
-        {
-            var zoneWeathers = ipcGetWeatherList.InvokeFunc();
-            var allWeathers = ipcGetWeathers.InvokeFunc();
-
-            if (zoneWeathers.TryGetValue(territoryId, out var zoneData)
-                && zoneData.WeatherList is { Count: > 0 })
-            {
-                var result = new Dictionary<byte, string>();
-                foreach (var id in zoneData.WeatherList)
-                {
-                    if (allWeathers.TryGetValue(id, out var name))
-                        result[id] = name;
-                }
-                if (result.Count > 0) return result;
-            }
-        }
-        catch { /* Weatherman indisponible pour les données zone */ }
-
-        return GetAllWeathers();
-    }
-
-    public uint GetWeatherIconId(byte weatherId)
-    {
-        return weatherIcons.GetValueOrDefault(weatherId, 0u);
-    }
-
-    // Applique une météo
-    public void SetWeather(byte weatherId)
-    {
-        if (weatherPatchAddr == nint.Zero)
-        {
-            Plugin.Log.Error("[MasterEvent] Cannot set weather: patch address not found");
-            return;
-        }
-
         if (weatherId == 0)
         {
-            DisableWeatherPatch();
+            if (weatherOverrideEnabled && weatherHook != null)
+            {
+                // Forcer un recalcul immédiat de la météo en appelant la fonction originale
+                var wm = FFXIVClientStructs.FFXIV.Client.Game.WeatherManager.Instance();
+                if (wm != null)
+                    weatherHook.Original((nint)wm);
+
+                weatherHook.Disable();
+                weatherOverrideEnabled = false;
+                overrideWeatherId = 0;
+                Plugin.Log.Info("[WeatherService] Override météo désactivé, météo du jeu restaurée");
+            }
             return;
         }
 
-        EnableWeatherPatch(weatherId);
-    }
+        var env = EnvManager.Instance();
+        if (env == null)
+        {
+            Plugin.Log.Error("[WeatherService] EnvManager non disponible");
+            return;
+        }
 
-    // Active un override d'heure éorzéenne via patch mémoire direct
+        // Écriture directe dans la mémoire du jeu
+        env->ActiveWeather = weatherId;
+        env->TransitionTime = 0.5f;
+        overrideWeatherId = weatherId;
+
+        // Activer le hook pour empêcher le jeu de changer la météo
+        if (!weatherOverrideEnabled && weatherHook != null)
+        {
+            weatherHook.Enable();
+            weatherOverrideEnabled = true;
+        }
+
+        Plugin.Log.Info($"[WeatherService] Météo définie : id={weatherId}");
+    }
     public void SetTime(uint eorzeaSeconds)
     {
         if (timePatchAddr == nint.Zero)
         {
-            Plugin.Log.Error("[MasterEvent] Cannot set time: patch address not found");
+            Plugin.Log.Error("[WeatherService] Impossible de définir l'heure : adresse de patch non trouvée");
             return;
         }
 
-        activeTimeOverride = eorzeaSeconds % SecondsInDay;
-        EnableTimePatch(activeTimeOverride);
-        Plugin.Log.Info($"[MasterEvent] Time override set: {activeTimeOverride}s ({SecondsToHour(activeTimeOverride):00}:00)");
+        overrideTimeSeconds = eorzeaSeconds % SecondsInDay;
+        EnableTimePatch(overrideTimeSeconds);
+        Plugin.Log.Info($"[WeatherService] Heure définie : {overrideTimeSeconds}s ({SecondsToHour(overrideTimeSeconds):00}:00)");
     }
 
-    // Désactive l'override de l'heure éorzéenne et restaure les bytes originaux
+    /// <summary>Désactive l'override du temps et restaure le comportement normal.</summary>
     public void ClearTime()
     {
-        activeTimeOverride = 0;
+        overrideTimeSeconds = 0;
         DisableTimePatch();
-        Plugin.Log.Info("[MasterEvent] Time override cleared");
+        Plugin.Log.Info("[WeatherService] Override temps désactivé");
     }
 
     public void TickTimeOverride()
     {
-        if (activeTimeOverride == 0 || timeValueAddr == nint.Zero) return;
-        SafeMemory.WriteBytes(timeValueAddr, BitConverter.GetBytes(activeTimeOverride));
+        if (overrideTimeSeconds == 0 || timeValueAddr == nint.Zero) return;
+        SafeMemory.WriteBytes(timeValueAddr, BitConverter.GetBytes(overrideTimeSeconds));
     }
 
     private void EnableTimePatch(uint eorzeaSeconds)
@@ -199,11 +171,10 @@ public class WeatherService : IDisposable
         {
             timeValueAddr = timePatchAddr + TimeValueOffsetInPatch;
             timePatchEnabled = true;
-            Plugin.Log.Info($"[MasterEvent] Time patch enabled: {eorzeaSeconds}s");
         }
         else
         {
-            Plugin.Log.Error("[MasterEvent] Failed to write time patch bytes");
+            Plugin.Log.Error("[WeatherService] Échec écriture du patch temps");
         }
     }
 
@@ -215,13 +186,77 @@ public class WeatherService : IDisposable
         {
             timePatchEnabled = false;
             timeValueAddr = nint.Zero;
-            Plugin.Log.Info("[MasterEvent] Time patch disabled, original bytes restored");
         }
         else
         {
-            Plugin.Log.Error("[MasterEvent] Failed to restore original time bytes");
+            Plugin.Log.Error("[WeatherService] Échec restauration des bytes originaux du temps");
         }
     }
+
+    public Dictionary<byte, string> GetWeathersForCurrentZone()
+    {
+        var territoryId = Plugin.ClientState.TerritoryType;
+        if (territoryId == 0) return GetAllWeathers();
+
+        // Vérifier le cache
+        if (territoryWeatherCache.TryGetValue(territoryId, out var cached))
+            return cached;
+
+        var result = new Dictionary<byte, string>();
+
+        try
+        {
+            var territorySheet = Plugin.DataManager.GetExcelSheet<TerritoryType>();
+            if (territorySheet != null && territorySheet.TryGetRow(territoryId, out var territory))
+            {
+                var weatherRateRef = territory.WeatherRate;
+                if (weatherRateRef.RowId != 0)
+                {
+                    var weatherRateSheet = Plugin.DataManager.GetExcelSheet<WeatherRate>();
+                    if (weatherRateSheet != null && weatherRateSheet.TryGetRow(weatherRateRef.RowId, out var weatherRate))
+                    {
+                        for (var i = 0; i < weatherRate.Weather.Count; i++)
+                        {
+                            var weatherRef = weatherRate.Weather[i];
+                            if (!weatherRef.IsValid || weatherRef.RowId == 0) continue;
+
+                            var id = (byte)weatherRef.RowId;
+                            var name = weatherNames.GetValueOrDefault(id, $"Weather {id}");
+                            result[id] = name;
+                        }
+                    }
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            Plugin.Log.Debug($"[WeatherService] Erreur lecture Lumina zone {territoryId}: {ex.Message}");
+        }
+
+        if (result.Count == 0)
+            result = GetAllWeathers();
+
+        // Mettre en cache
+        territoryWeatherCache[territoryId] = result;
+        return result;
+    }
+
+    public Dictionary<byte, string> GetAllWeathers()
+    {
+        return weatherNames.Count > 0 ? new Dictionary<byte, string>(weatherNames) : FallbackWeathers;
+    }
+
+    public uint GetWeatherIconId(byte weatherId)
+    {
+        return weatherIcons.GetValueOrDefault(weatherId, 0u);
+    }
+
+    public void ClearWeatherCache()
+    {
+        territoryWeatherCache.Clear();
+    }
+
+    // Lecture du temps
 
     public static unsafe uint GetCurrentEorzeaTimeSeconds()
     {
@@ -237,62 +272,70 @@ public class WeatherService : IDisposable
     public static int SecondsToHour(uint seconds) => (int)(seconds / 3600 % 24);
     public static uint HourToSeconds(int hour) => (uint)(hour * 3600);
 
+    // ── Données statiques de secours ──
 
-    private void EnableWeatherPatch(byte weatherId)
+    public static readonly Dictionary<byte, string> FallbackWeathers = new()
     {
-        // Écrire le patch
-        var patchBytes = new byte[] { 0xB2, weatherId, 0x90, 0x90 };
-        if (SafeMemory.WriteBytes(weatherPatchAddr, patchBytes))
-        {
-            weatherPatchEnabled = true;
+        { 1, "Ciel dégagé" },
+        { 2, "Beau temps" },
+        { 3, "Couvert" },
+        { 4, "Pluie" },
+        { 7, "Brouillard" },
+        { 8, "Orage" },
+        { 9, "Tempête de sable" },
+        { 14, "Neige" },
+        { 15, "Blizzard" },
+        { 16, "Canicule" },
+    };
 
-            Plugin.Log.Info($"[MasterEvent] Weather patch enabled: id={weatherId}");
-        }
-        else
-        {
-            Plugin.Log.Error("[MasterEvent] Failed to write weather patch bytes");
-        }
-    }
+    // ── Chargement initial des données Lumina ──
 
-    private void DisableWeatherPatch()
-    {
-        if (!weatherPatchEnabled || weatherOrigBytes == null) return;
-
-        if (SafeMemory.WriteBytes(weatherPatchAddr, weatherOrigBytes))
-        {
-            weatherPatchEnabled = false;
-
-            Plugin.Log.Info("[MasterEvent] Weather patch disabled, original bytes restored");
-        }
-        else
-        {
-            Plugin.Log.Error("[MasterEvent] Failed to restore original weather bytes");
-        }
-    }
-
-    private void LoadWeatherIcons()
+    private void LoadWeatherData()
     {
         try
         {
             var sheet = Plugin.DataManager.GetExcelSheet<Weather>();
+            if (sheet == null) return;
+
             foreach (var row in sheet)
             {
                 var id = (byte)row.RowId;
                 var iconId = Convert.ToUInt32(row.Icon);
                 if (iconId != 0)
                     weatherIcons[id] = iconId;
+
+                var name = row.Name.ToString();
+                if (!string.IsNullOrEmpty(name))
+                    weatherNames[id] = name;
             }
+
+            Plugin.Log.Info($"[WeatherService] {weatherNames.Count} météos chargées depuis Lumina");
         }
         catch (Exception ex)
         {
-            Plugin.Log.Debug($"[MasterEvent] Failed to load weather icons: {ex.Message}");
+            Plugin.Log.Debug($"[WeatherService] Erreur chargement icônes météo : {ex.Message}");
         }
     }
 
+    // Nettoyage
 
     public void Dispose()
     {
+        // Restaurer la météo du jeu si override actif
+        if (weatherOverrideEnabled && weatherHook != null)
+        {
+            unsafe
+            {
+                var wm = FFXIVClientStructs.FFXIV.Client.Game.WeatherManager.Instance();
+                if (wm != null)
+                    weatherHook.Original((nint)wm);
+            }
+            weatherHook.Disable();
+        }
+
+        // Restaurer le temps
         DisableTimePatch();
-        DisableWeatherPatch();
+
+        weatherHook?.Dispose();
     }
 }

--- a/MasterEvent/UI/GmWindow.Group.cs
+++ b/MasterEvent/UI/GmWindow.Group.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
 using Dalamud.Bindings.ImGui;
@@ -140,6 +141,21 @@ public sealed partial class GmWindow
 
             // Players section
             ImGui.TextColored(MasterEventTheme.AccentColor, Loc.Get("Group.Players"));
+
+            // Compteur par groupe en mode alliance
+            if (session.IsAllianceMode)
+            {
+                ImGui.SameLine();
+                var groupCounts = session.GetGroupCounts();
+                var countParts = new List<string>();
+                foreach (var (label, count) in groupCounts)
+                    countParts.Add($"{label}:{count}");
+                if (countParts.Count > 0)
+                {
+                    ImGui.TextColored(new Vector4(0.5f, 0.5f, 0.5f, 1f),
+                        $"  ({string.Join(" | ", countParts)})");
+                }
+            }
             ImGui.Spacing();
 
             var hasPlayers = false;
@@ -169,6 +185,14 @@ public sealed partial class GmWindow
                 ImGui.TextColored(MasterEventTheme.AccentColor, crownStr);
             }
             ImGui.SameLine();
+        }
+
+        // Badge de groupe alliance (avant le nom)
+        if (session.IsAllianceMode && !isGmSection && player.GroupLabel != null)
+        {
+            var groupColor = GetGroupColor(player.GroupLabel);
+            ImGui.TextColored(groupColor, $"[{player.GroupLabel}]");
+            ImGui.SameLine(0, 4f * ImGuiHelpers.GlobalScale);
         }
 
         // Player name
@@ -217,6 +241,27 @@ public sealed partial class GmWindow
                 ImGui.BeginTooltip();
                 ImGui.TextUnformatted(promoteTooltip);
                 ImGui.EndTooltip();
+            }
+
+            // Bouton kick (uniquement pour les joueurs alliance)
+            if (player.IsAlliancePlayer)
+            {
+                ImGui.SameLine();
+                ImGui.PushStyleColor(ImGuiCol.Text, new Vector4(0.9f, 0.3f, 0.3f, 1f));
+                using (Plugin.PluginInterface.UiBuilder.IconFontFixedWidthHandle.Push())
+                {
+                    if (ImGui.Button(FontAwesomeIcon.UserTimes.ToIconString() + "##kick_" + player.Hash))
+                    {
+                        session.RemoveAlliancePlayer(player.Hash);
+                    }
+                }
+                ImGui.PopStyleColor();
+                if (ImGui.IsItemHovered())
+                {
+                    ImGui.BeginTooltip();
+                    ImGui.TextUnformatted(Loc.Get("Alliance.Kick"));
+                    ImGui.EndTooltip();
+                }
             }
         }
 
@@ -488,5 +533,24 @@ public sealed partial class GmWindow
                 }
             }
         }
+    }
+
+    private static readonly Vector4[] GroupColors =
+    [
+        new(0.4f, 0.7f, 1.0f, 1f),  // A — bleu clair
+        new(1.0f, 0.6f, 0.3f, 1f),  // B — orange
+        new(0.5f, 0.9f, 0.5f, 1f),  // C — vert
+        new(0.9f, 0.5f, 0.9f, 1f),  // D — violet
+        new(1.0f, 0.9f, 0.4f, 1f),  // E — jaune
+        new(0.4f, 0.9f, 0.9f, 1f),  // F — cyan
+        new(1.0f, 0.5f, 0.5f, 1f),  // G — rouge
+        new(0.7f, 0.7f, 0.7f, 1f),  // H — gris
+    ];
+
+    private static Vector4 GetGroupColor(string label)
+    {
+        if (label.Length == 1 && label[0] >= 'A' && label[0] <= 'H')
+            return GroupColors[label[0] - 'A'];
+        return new Vector4(0.6f, 0.6f, 0.6f, 1f);
     }
 }

--- a/MasterEvent/UI/GmWindow.Settings.cs
+++ b/MasterEvent/UI/GmWindow.Settings.cs
@@ -311,7 +311,7 @@ public sealed partial class GmWindow
 
     private void DrawPrivacyContent()
     {
-        DrawSectionHeader(1);
+        DrawSectionHeader(2);
 
         ImGui.TextColored(MasterEventTheme.AccentColor, Loc.Get("Privacy.ConsentTitle"));
         ImGui.Spacing();
@@ -369,9 +369,11 @@ public sealed partial class GmWindow
         ImGui.Spacing();
 
         var dimColor = new Vector4(0.7f, 0.7f, 0.7f, 1f);
-        ImGui.TextColored(dimColor, Loc.Get("Privacy.RightAccess"));
-        ImGui.TextColored(dimColor, Loc.Get("Privacy.RightErasure"));
-        ImGui.TextColored(dimColor, Loc.Get("Privacy.RightObject"));
+        ImGui.PushStyleColor(ImGuiCol.Text, dimColor);
+        ImGui.TextWrapped(Loc.Get("Privacy.RightAccess"));
+        ImGui.TextWrapped(Loc.Get("Privacy.RightErasure"));
+        ImGui.TextWrapped(Loc.Get("Privacy.RightObject"));
+        ImGui.PopStyleColor();
 
         ImGui.Spacing();
         ImGui.TextColored(new Vector4(0.5f, 0.5f, 0.5f, 1f), Loc.Get("Privacy.Controller"));
@@ -645,31 +647,7 @@ public sealed partial class GmWindow
 
     private void DrawAdvancedContent()
     {
-        DrawSectionHeader(2);
-
-        // ── Compatibilité plugins ──
-        ImGui.TextColored(MasterEventTheme.AccentColor, Loc.Get("Advanced.PluginCompat"));
-        ImGui.Spacing();
-
-        DrawPluginStatus("Weatherman", session.IsWeathermanInstalled);
-        ImGui.SameLine();
-        ImGui.TextColored(new Vector4(0.5f, 0.5f, 0.5f, 1f), "-");
-        ImGui.SameLine();
-        if (session.IsWeathermanInstalled)
-        {
-            var weatherOk = session.IsWeatherPatchActive || session.IsTimePatchActive;
-            ImGui.TextColored(
-                weatherOk ? new Vector4(0.5f, 0.5f, 0.5f, 1f) : new Vector4(0.7f, 0.7f, 0.2f, 1f),
-                weatherOk ? Loc.Get("Advanced.PluginReady") : Loc.Get("Advanced.PluginPartial"));
-        }
-        else
-        {
-            ImGui.TextColored(new Vector4(0.5f, 0.5f, 0.5f, 1f), Loc.Get("Advanced.PluginWeathermanHint"));
-        }
-
-        ImGuiHelpers.ScaledDummy(6f);
-        ImGui.Separator();
-        ImGuiHelpers.ScaledDummy(4f);
+        DrawSectionHeader(3);
 
         ImGui.PushStyleColor(ImGuiCol.Text, new Vector4(1f, 0.6f, 0.2f, 1f));
         ImGui.PushTextWrapPos(ImGui.GetCursorPosX() + ImGui.GetContentRegionAvail().X);
@@ -717,20 +695,5 @@ public sealed partial class GmWindow
             ImGui.SameLine();
             ImGui.TextColored(new Vector4(0.5f, 0.5f, 0.5f, 1f), "— " + Loc.Get("Advanced.Cmd.Gm"));
         }
-    }
-
-    private static void DrawPluginStatus(string name, bool installed)
-    {
-        var icon = installed ? FontAwesomeIcon.Check : FontAwesomeIcon.Times;
-        var color = installed ? new Vector4(0.2f, 0.8f, 0.2f, 1f) : new Vector4(0.8f, 0.3f, 0.3f, 1f);
-
-        ImGui.TextUnformatted(name);
-        ImGui.SameLine();
-        ImGui.PushStyleColor(ImGuiCol.Text, color);
-        using (Plugin.PluginInterface.UiBuilder.IconFontFixedWidthHandle.Push())
-        {
-            ImGui.TextUnformatted(icon.ToIconString());
-        }
-        ImGui.PopStyleColor();
     }
 }

--- a/MasterEvent/UI/PlayerWindow.cs
+++ b/MasterEvent/UI/PlayerWindow.cs
@@ -166,6 +166,25 @@ public sealed class PlayerWindow : MasterEventWindowBase
             ImGui.SameLine();
             ImGui.TextUnformatted(session.AllianceRoomCode);
             ImGui.SameLine();
+
+            var localPlayer = session.PartyMembers.FirstOrDefault(p => p.Hash == session.LocalPlayerHash);
+            if (localPlayer?.GroupLabel != null)
+            {
+                var groupColor = GetGroupColor(localPlayer.GroupLabel);
+                ImGui.TextColored(groupColor, $"[{localPlayer.GroupLabel}]");
+                ImGui.SameLine();
+            }
+
+            var groupCounts = session.GetGroupCounts();
+            if (groupCounts.Count > 1)
+            {
+                var parts = new System.Collections.Generic.List<string>();
+                foreach (var (label, count) in groupCounts)
+                    parts.Add($"{label}:{count}");
+                ImGui.TextColored(new Vector4(0.5f, 0.5f, 0.5f, 1f), $"({string.Join(" | ", parts)})");
+                ImGui.SameLine();
+            }
+
             ImGui.PushStyleColor(ImGuiCol.Button, new Vector4(0.6f, 0.15f, 0.15f, 1f));
             ImGui.PushStyleColor(ImGuiCol.ButtonHovered, new Vector4(0.7f, 0.2f, 0.2f, 1f));
             if (ImGui.SmallButton(Loc.Get("Alliance.Leave") + "##leave_alliance"))
@@ -829,5 +848,24 @@ public sealed class PlayerWindow : MasterEventWindowBase
                 ImGui.EndTooltip();
             }
         }
+    }
+
+    private static readonly Vector4[] GroupColors =
+    [
+        new(0.4f, 0.7f, 1.0f, 1f),
+        new(1.0f, 0.6f, 0.3f, 1f),
+        new(0.5f, 0.9f, 0.5f, 1f),
+        new(0.9f, 0.5f, 0.9f, 1f),
+        new(1.0f, 0.9f, 0.4f, 1f),
+        new(0.4f, 0.9f, 0.9f, 1f),
+        new(1.0f, 0.5f, 0.5f, 1f),
+        new(0.7f, 0.7f, 0.7f, 1f),
+    ];
+
+    private static Vector4 GetGroupColor(string label)
+    {
+        if (label.Length == 1 && label[0] >= 'A' && label[0] <= 'H')
+            return GroupColors[label[0] - 'A'];
+        return new Vector4(0.6f, 0.6f, 0.6f, 1f);
     }
 }

--- a/MasterEventRelay/src/models.rs
+++ b/MasterEventRelay/src/models.rs
@@ -19,6 +19,8 @@ pub struct IncomingMessage {
     pub target_hash: Option<String>,
     #[serde(rename = "canEdit")]
     pub can_edit: Option<bool>,
+    #[serde(rename = "groupId")]
+    pub group_id: Option<String>,
 }
 
 /// Informations d'un client connecté dans une room.
@@ -29,6 +31,8 @@ pub struct ClientInfo {
     pub is_leader: bool,
     pub is_promoted: bool,
     pub version: String,
+    #[allow(dead_code)]
+    pub group_id: Option<String>,
 }
 
 /// Confirmation d'adhésion à une room.
@@ -55,6 +59,8 @@ pub struct PlayerJoined {
     pub player_hash: String,
     #[serde(rename = "playerCount")]
     pub player_count: usize,
+    #[serde(rename = "groupId", skip_serializing_if = "Option::is_none")]
+    pub group_id: Option<String>,
 }
 
 /// Notification de départ d'un joueur.

--- a/MasterEventRelay/src/ws/broadcast.rs
+++ b/MasterEventRelay/src/ws/broadcast.rs
@@ -1,29 +1,79 @@
+use tracing::info;
+
 use crate::state::{AppState, Room};
 
 /// Envoie un message à tous les clients d'une room sauf l'émetteur.
 /// Met à jour le cache si nécessaire.
+/// Log le résultat de la transmission pour le diagnostic.
 pub fn relay_to_room(room: &mut Room, exclude_id: u64, msg: &serde_json::Value) {
     room.last_activity = AppState::now_ms();
 
+    let msg_type = msg
+        .get("type")
+        .and_then(|t| t.as_str())
+        .unwrap_or("unknown");
+
     // Mise à jour du cache selon le type de message
-    if let Some(msg_type) = msg.get("type").and_then(|t| t.as_str()) {
-        match msg_type {
-            "update" => room.cached_state = Some(msg.clone()),
-            "clear" => room.cached_state = None,
-            _ => {}
-        }
+    match msg_type {
+        "update" => room.cached_state = Some(msg.clone()),
+        "clear" => room.cached_state = None,
+        _ => {}
     }
 
     let payload = serde_json::to_string(msg).unwrap();
 
+    // Identifier l'émetteur
+    let sender_name = room
+        .clients
+        .get(&exclude_id)
+        .map(|c| c.info.player_name.as_str())
+        .unwrap_or("?");
+
+    // Compter les destinataires (tous sauf l'émetteur)
+    let recipients: Vec<u64> = room
+        .clients
+        .keys()
+        .filter(|&&id| id != exclude_id)
+        .copied()
+        .collect();
+
+    if recipients.is_empty() {
+        info!(
+            "[relay] {} from {} (client {}) — no other members in room, message not forwarded",
+            msg_type, sender_name, exclude_id
+        );
+        return;
+    }
+
     // Collecter les IDs des clients déconnectés pour nettoyage
+    let mut delivered = 0u32;
+    let mut failed = 0u32;
     let mut dead_clients = Vec::new();
 
-    for (&id, handle) in &room.clients {
-        if id != exclude_id && handle.sender.send(payload.clone()).is_err() {
-            dead_clients.push(id);
+    for &id in &recipients {
+        if let Some(handle) = room.clients.get(&id) {
+            if handle.sender.send(payload.clone()).is_ok() {
+                delivered += 1;
+            } else {
+                failed += 1;
+                dead_clients.push(id);
+            }
         }
     }
+
+    info!(
+        "[relay] {} from {} (client {}) — delivered to {}/{} members{}",
+        msg_type,
+        sender_name,
+        exclude_id,
+        delivered,
+        recipients.len(),
+        if failed > 0 {
+            format!(" ({} failed)", failed)
+        } else {
+            String::new()
+        }
+    );
 
     for id in dead_clients {
         room.clients.remove(&id);

--- a/MasterEventRelay/src/ws/handlers.rs
+++ b/MasterEventRelay/src/ws/handlers.rs
@@ -51,12 +51,15 @@ pub fn handle_join(
     let existing_leader = room.clients.values().any(|c| c.info.is_leader);
     let grant_leader = wants_leader && !existing_leader;
 
+    let group_id = msg.group_id.clone();
+
     let info = ClientInfo {
         player_name: player_name.clone(),
         player_hash: hash.clone(),
         is_leader: grant_leader,
         is_promoted: false,
         version: client_version.clone(),
+        group_id: group_id.clone(),
     };
 
     let handle = ClientHandle {
@@ -92,6 +95,7 @@ pub fn handle_join(
         player_name: player_name.clone(),
         player_hash: hash.clone(),
         player_count,
+        group_id: group_id.clone(),
     })
     .unwrap();
 

--- a/MasterEventRelay/src/ws/session.rs
+++ b/MasterEventRelay/src/ws/session.rs
@@ -79,7 +79,7 @@ pub async fn handle_session(state: AppState, socket: WebSocket, client_id: u64) 
                         handlers::handle_leave(&state, client_id, &mut current_room, true);
                     }
                     // Messages nécessitant le statut leader ou promu
-                    "update" | "clear" | "playerUpdate" | "templateShare" | "turnUpdate" | "turnClear" => {
+                    "update" | "clear" | "playerUpdate" | "templateShare" | "turnUpdate" | "turnClear" | "weatherUpdate" | "timeUpdate" | "allianceKick" => {
                         if let Some(ref room_key) = current_room {
                             if let Some(mut room) = state.rooms.get_mut(room_key) {
                                 let authorized = room
@@ -89,6 +89,8 @@ pub async fn handle_session(state: AppState, socket: WebSocket, client_id: u64) 
                                     .unwrap_or(false);
                                 if authorized {
                                     relay_to_room(room.value_mut(), client_id, &raw_value);
+                                } else {
+                                    warn!("[relay] {} from client {} rejected — not leader/promoted in room {}", msg_type, client_id, room_key);
                                 }
                             }
                         }

--- a/README.md
+++ b/README.md
@@ -100,12 +100,15 @@
 - **Bonus/malus temporaire** par joueur (MJ uniquement)
 - Indicateur de connexion en temps r&#xE9;el par joueur
 - **Mode Raid Alliance** : g&#xE9;n&#xE9;ration d&#x27;un code de salle 6 caract&#xE8;res pour connecter jusqu&#x27;&#xE0; 24 joueurs (3 groupes de 8) sur la m&#xEA;me session, ind&#xE9;pendamment du groupe FFXIV local
+- **Indicateurs visuels par groupe** : badge color&#xE9; `[A]`, `[B]`, `[C]`&#x2026; et compteur par groupe
+- **Persistance du code alliance** : survit aux reloads/crashes, auto-rejoin &#xE0; la reconnexion
+- **Kick de joueur** : retrait de joueurs individuels de l&#x27;alliance avec notification
 
 ### Synchronisation multijoueur
 
 - Communication en temps r&#xE9;el via WebSocket (WSS/TLS)
 - Serveur relais d&#xE9;di&#xE9; en Rust avec gestion de salles par groupe
-- **Mode Alliance** : salles par code (ind&#xE9;pendant du groupe FFXIV), tracking automatique des joueurs des autres groupes
+- **Mode Alliance** : salles par code (ind&#xE9;pendant du groupe FFXIV), tracking automatique des joueurs des autres groupes, identification par groupe d&#x27;origine
 - **Reconnexion automatique** avec backoff exponentiel (1s &#xE0; 30s)
 - **R&#xE9;cup&#xE9;ration de session** : cache serveur + cache local en cas de crash
 - Notifications de connexion/d&#xE9;connexion en chat
@@ -115,10 +118,10 @@
 
 - **Contr&#xF4;le de la m&#xE9;t&#xE9;o** : changement du temps affich&#xE9; en jeu (d&#xE9;gag&#xE9;, pluie, orage, brouillard&#x2026;)
 - **Contr&#xF4;le de l&#x27;heure** : gel de l&#x27;heure &#xE9;orz&#xE9;enne &#xE0; une valeur choisie (0h&#x2013;23h)
-- **Patch m&#xE9;moire direct** : fonctionne de mani&#xE8;re autonome, sans d&#xE9;pendance externe pour l&#x27;application des changements
-- **Listes de m&#xE9;t&#xE9;o par zone** via Weatherman IPC (si install&#xE9;), avec liste de secours int&#xE9;gr&#xE9;e
-- **Synchronisation** : m&#xE9;t&#xE9;o et heure diffus&#xE9;es &#xE0; tous les joueurs connect&#xE9;s
-- **R&#xE9;initialisation** : retour &#xE0; la m&#xE9;t&#xE9;o et l&#x27;heure normales du jeu en un clic
+- **Enti&#xE8;rement autonome** : aucune d&#xE9;pendance externe (ni Weatherman, ni Brio). Hook direct sur les fonctions du jeu + patch m&#xE9;moire sur le rendu
+- **Listes de m&#xE9;t&#xE9;o par zone** charg&#xE9;es depuis les donn&#xE9;es Lumina du jeu
+- **Synchronisation** : m&#xE9;t&#xE9;o et heure diffus&#xE9;es &#xE0; tous les joueurs connect&#xE9;s via le relay
+- **R&#xE9;initialisation** : retour instantan&#xE9; &#xE0; la m&#xE9;t&#xE9;o et l&#x27;heure normales du jeu
 
 ### Presets
 


### PR DESCRIPTION
  # 🔧 v1.3.1.4006                                                                                                                                                                        
                                                                                                                                                                                        
  ## Météo & Heure Indépendance totale                       
                                                                                                                                                                                        
Le contrôle de la météo et de l'heure ne dépend plus du plugin Weatherman. MasterEvent gère désormais tout en autonomie :
                                                                                                                                                                                        

>   - Météo : hook direct sur la fonction de mise à jour du jeu + écriture dans EnvManager (inspiré de Brio)                                                                              
>   - Heure : patch mémoire sur la fonction de rendu (seule méthode affectant le rendu visuel du ciel/éclairage)
>   - Données météo : chargées depuis les fichiers Lumina du jeu (plus besoin d'IPC)                                                                                                      
>   - Revert météo : la météo du jeu est restaurée instantanément à la désactivation (appel de la fonction originale)
>   - Synchronisation relay : les messages weatherUpdate et timeUpdate sont désormais correctement relayés aux joueurs du groupe             

Ni le MJ ni les joueurs n'ont besoin de Weatherman installé.                                                                                                                        
                                                            
 ## Mode Raid Alliance : Améliorations                                                                                                                                                    
   

>   - Indicateurs visuels par groupe : chaque joueur affiche un badge coloré [A], [B], [C]... selon son groupe d'origine                                                                  
>   - Compteur par groupe : affiché à côté du titre "Joueurs" (ex: A:4 | B:3)
>   - Persistance du code alliance : le code survit aux reloads et crashes du plugin, et n'est effacé qu'à la dissolution explicite de l'alliance                                         
>   - Auto-rejoin : les joueurs reconnectés automatiquement à la room alliance après un crash ou un changement de zone                                                                    
>   - Kick de joueur : le MJ peut retirer un joueur spécifique de l'alliance (bouton dans la liste des joueurs). Le joueur kické est notifié et déconnecté proprement                     
>   - Indicateurs dans la fenêtre joueur : le badge de groupe et le compteur sont aussi visibles côté joueur    

                                                                          
                                                            
## Autres corrections                                                                                                                                                                           

>   - Correction des en-têtes décalés dans les onglets Paramètres (Vie privée / Avancé affichaient le mauvais titre)                                                                      
>   - Retour à la ligne automatique pour les textes longs dans l'onglet Vie privée
>   - Suppression de la section "Compatibilité plugins" dans l'onglet Avancé (plus nécessaire)                                                                                            
>   - Mise à jour des tooltips : suppression des mentions "Nécessite Weatherman"           

                                                                                               
   
## Serveur Relay                                                                                                                                                                                 
                                                            
>   - Ajout du routage des messages weatherUpdate, timeUpdate et allianceKick                                                                                                             
>   - Transmission du groupId d'origine dans les messages playerJoined
>   - Logs de diagnostic : traçabilité complète des messages relayés (émetteur, nombre de destinataires, échecs)                                                                          
                                                                                                                      